### PR TITLE
Size consolidation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,15 @@
+Legend:
+    ** Incompatible API change
+    + Feature addition
+    ! Bug fix
+    - Other change (performance, docs, etc)
+
 0.2 [unreleased]
+    ** All pixel measurements have been moved to pixel_size,
+        pixel_width, pixel_height attributes.
+        The size, width and height attributes of MapTile, MapObject,
+        and TilesetTile are now in units of map tiles.
+
     ! Fix hashes of TilesetTile, improve equality tests
     + Support testing for empty layers with bool(layer)
     + Support for export/import to/from a dict compatible with Tiled's

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,10 +5,10 @@ Legend:
     - Other change (performance, docs, etc)
 
 0.2 [unreleased]
-    ** All pixel measurements have been moved to pixel_size,
-        pixel_width, pixel_height attributes.
-        The size, width and height attributes of MapTile, MapObject,
-        and TilesetTile are now in units of map tiles.
+    ** Pixel measurements have been moved to pixel_size, pixel_width,
+        pixel_height (and pixel_pos, ~_x, ~_y) attributes.
+        The size, width and height attributes of MapTile and MapObject
+        are now in units of map tiles.
 
     ! Fix hashes of TilesetTile, improve equality tests
     + Support testing for empty layers with bool(layer)

--- a/tmxlib/__init__.py
+++ b/tmxlib/__init__.py
@@ -1543,6 +1543,20 @@ class TileLikeObject(SizeMixin, PixelSizeMixin):
         else:
             return 0, 0
 
+    @property
+    def pixel_x(self):
+        return self.pixel_pos[0]
+    @pixel_x.setter
+    def pixel_x(self, value):
+        self.pixel_pos = value, self.pixel_pos[1]
+
+    @property
+    def pixel_y(self):
+        return self.pixel_pos[1]
+    @pixel_y.setter
+    def pixel_y(self, value):
+        self.pixel_pos = self.pixel_pos[0], value
+
 
 class MapTile(TileLikeObject):
     """References a particular spot on a tile layer
@@ -1633,6 +1647,11 @@ class MapTile(TileLikeObject):
     @property
     def pos(self):
         return self._pos
+
+    @property
+    def pixel_pos(self):
+        px_parent = self.map.tile_size
+        return self.x * px_parent[0], (self.y + self.height) * px_parent[1]
 
     @property
     def properties(self):
@@ -1838,20 +1857,6 @@ class MapObject(TileLikeObject, SizeMixin):
         y += 1
         self.pixel_pos = (x * self.layer.map.tile_width,
                 y * self.layer.map.tile_height)
-
-    @property
-    def pixel_x(self):
-        return self.pixel_pos[0]
-    @pixel_x.setter
-    def pixel_x(self, value):
-        self.pixel_pos = value, self.pixel_pos[1]
-
-    @property
-    def pixel_y(self):
-        return self.pixel_pos[1]
-    @pixel_y.setter
-    def pixel_y(self, value):
-        self.pixel_pos = self.pixel_pos[0], value
 
     @property
     def pixel_size(self):

--- a/tmxlib/__init__.py
+++ b/tmxlib/__init__.py
@@ -260,7 +260,7 @@ class TilesetList(NamedElementList):
 
         This reassigns the GIDs of tiles to match the new situation.
 
-        If an used tilesed was removed, raise a ValueError. (Note that this
+        If an used tileset was removed, raise a ValueError. (Note that this
         method by itself won't restore the previous state.)
         """
         gid_map = dict()
@@ -578,7 +578,8 @@ class TilesetTile(PixelSizeMixin):
 
         .. attribute:: pixel_size
 
-            The size of the tile, in pixels
+            The size of the tile, in pixels. Also available as
+            (``pixel_width``, ``pixel_height``).
 
         .. attribute:: properties
 
@@ -1595,6 +1596,10 @@ class MapTile(TileLikeObject):
 
             Empty tiles have (0, 0) size.
 
+        .. attribute:: pixel_size
+
+            Size of the tile in pixels.
+
         .. autoattribute:: tileset
         .. autoattribute:: number
         .. autoattribute:: image
@@ -1610,12 +1615,16 @@ class MapTile(TileLikeObject):
             See :class:`TilesetTile`.
 
 
-    Unpacked `pos` and `size` attributes:
+    Unpacked position and size attributes:
 
         .. attribute:: x
         .. attribute:: y
         .. attribute:: width
         .. attribute:: height
+        .. attribute:: pixel_x
+        .. attribute:: pixel_y
+        .. attribute:: pixel_width
+        .. attribute:: pixel_height
 
     """
     def __init__(self, layer, pos):
@@ -1679,9 +1688,9 @@ class MapTile(TileLikeObject):
 class ObjectLayer(Layer, NamedElementList):
     """A layer of objects.
 
-    Acts as a :class:`named list <NamedList>` of objects. This means semantics
-    similar to layer/tileset lists: indexing by name is possible, where a name
-    references the first object of such name.
+    Acts as a :class:`named list <NamedElementList>` of objects. This means
+    semantics similar to layer/tileset lists: indexing by name is possible,
+    where a name references the first object of such name.
 
     See :class:`Layer` for the init arguments.
     """
@@ -1821,7 +1830,7 @@ class MapObject(TileLikeObject, SizeMixin):
 
             The map associated with this object
 
-    Unpacked `pos`, `pixel_pos`, and `size`:
+    Unpacked position and size attributes:
 
         .. attribute:: x
         .. attribute:: y
@@ -1829,6 +1838,8 @@ class MapObject(TileLikeObject, SizeMixin):
         .. attribute:: pixel_y
         .. attribute:: width
         .. attribute:: height
+        .. attribute:: pixel_width
+        .. attribute:: pixel_height
     """
     def __init__(self, layer, pixel_pos, size=None, pixel_size=None, name=None,
             type=None, value=0):

--- a/tmxlib/__init__.py
+++ b/tmxlib/__init__.py
@@ -14,7 +14,6 @@ __email__ = 'encukou@gmail.com'
 import array
 import collections
 import contextlib
-import itertools
 import functools
 
 import six
@@ -25,6 +24,7 @@ from tmxlib import fileio
 class UsedTilesetError(ValueError):
     """Raised when trying to remove a tileset from a map that is uses its tiles
     """
+
 
 class TilesetNotInMapError(ValueError):
     """Used when trying to use a tile from a tileset that's not in the map
@@ -108,13 +108,12 @@ class NamedElementList(collections.MutableSequence):
         """Same as __getitem__, but a returns default if not found
         """
         try:
-            index = self._get_index(index_or_name)
             return self[index_or_name]
         except (IndexError, KeyError):
             return default
 
     def __delitem__(self, index_or_name):
-        """Same as list's, except non-slice indices may be names instead of ints.
+        """Same as list's, except non-slice indices may be names.
         """
         with self.modification_context():
             if isinstance(index_or_name, slice):
@@ -399,7 +398,7 @@ class Map(fileio.ReadWriteBase, SizeMixin):
     def __init__(self, size, tile_size, orientation='orthogonal',
             base_path=None):
         self.orientation = orientation
-        self.size=size
+        self.size = size
         self.tile_size = tile_size
         self.tilesets = TilesetList(self)
         self.layers = LayerList(self)
@@ -883,7 +882,7 @@ class ImageTileset(Tileset):
     def from_dict(cls, dct):
         """Import from a dict compatible with Tiled's JSON plugin"""
         dct.pop('firstgid', None)
-        html_trans = source=dct.pop('transparentcolor', None)
+        html_trans = dct.pop('transparentcolor', None)
         if html_trans:
             trans = _parse_html_color(html_trans)
         else:
@@ -1156,7 +1155,6 @@ class Layer(object):
                 objectgroup=ObjectLayer,
             )[dct['type']]
         return subclass.from_dict(dct, *args, **kwargs)
-
 
 
 class TileLayer(Layer):
@@ -1658,7 +1656,6 @@ class ObjectLayer(Layer, NamedElementList):
         return bool(len(self))
 
     __bool__ = __nonzero__
-
 
     def to_dict(self):
         """Export to a dict compatible with Tiled's JSON plugin"""

--- a/tmxlib/fileio.py
+++ b/tmxlib/fileio.py
@@ -170,7 +170,6 @@ class TMXSerializer(object):
         assert root.tag == 'map'
         assert root.attrib.pop('version') == '1.0', 'Bad TMX file version'
 
-        tile_data = []
         args = dict(
                 size=(int(root.attrib.pop('width')),
                         int(root.attrib.pop('height'))),
@@ -249,7 +248,7 @@ class TMXSerializer(object):
                 'Unexpected tileset attributes: %s' % elem.attrib)
         for subelem in elem:
             if subelem.tag == 'image':
-                assert tileset.image == None
+                assert tileset.image is None
                 tileset.image = self.image_from_element(
                         self.image_class, subelem, base_path=base_path)
             elif subelem.tag == 'tile':

--- a/tmxlib/fileio.py
+++ b/tmxlib/fileio.py
@@ -470,7 +470,7 @@ class TMXSerializer(object):
                 width = subelem.attrib.pop('width', None)
                 height = subelem.attrib.pop('height', None)
                 if width is not None or height is not None:
-                    kwargs['size'] = int(width), int(height)
+                    kwargs['pixel_size'] = int(width), int(height)
                 assert not subelem.attrib, (
                     'Unexpected object attributes: %s' % subelem.attrib)
                 obj = self.object_class(**kwargs)
@@ -501,10 +501,9 @@ class TMXSerializer(object):
                 attrib['name'] = str(object.name)
             if object.type:
                 attrib['type'] = str(object.type)
-            if object.size != (0, 0) and not (object.tileset_tile and
-                    object.tileset_tile.size == object.size):
-                attrib['width'] = str(object.width)
-                attrib['height'] = str(object.height)
+            if not object.tileset_tile:
+                attrib['width'] = str(object.pixel_width)
+                attrib['height'] = str(object.pixel_height)
             obj_element = etree.Element('object', attrib=attrib)
             self.append_properties(obj_element, object.properties)
             element.append(obj_element)

--- a/tmxlib/image_pil.py
+++ b/tmxlib/image_pil.py
@@ -12,6 +12,7 @@ try:
 except AttributeError:
     raise ImportError('Incompatible version of the PIL library')
 
+
 class PilImage(tmxlib.Image):
     def load_image(self):
         """Load the image from self.data, and set self.size

--- a/tmxlib/test/data/equivcheck.json
+++ b/tmxlib/test/data/equivcheck.json
@@ -3,7 +3,7 @@
         {
          "data":[0, 0, 0, 0, 30, 0, 0, 0, 0],
          "height":3,
-         "name":"Tile layer",
+         "name":"Tile Layer",
          "opacity":1,
          "type":"tilelayer",
          "visible":true,

--- a/tmxlib/test/data/equivcheck.json
+++ b/tmxlib/test/data/equivcheck.json
@@ -1,0 +1,64 @@
+{ "height":3,
+ "layers":[
+        {
+         "data":[0, 0, 0, 0, 30, 0, 0, 0, 0],
+         "height":3,
+         "name":"Tile layer",
+         "opacity":1,
+         "type":"tilelayer",
+         "visible":true,
+         "width":3,
+         "x":0,
+         "y":0
+        }, 
+        {
+         "height":3,
+         "name":"Object Layer",
+         "objects":[
+                {
+                 "gid":30,
+                 "height":0,
+                 "name":"",
+                 "properties":
+                    {
+
+                    },
+                 "type":"",
+                 "visible":true,
+                 "width":0,
+                 "x":32,
+                 "y":64
+                }],
+         "opacity":1,
+         "type":"objectgroup",
+         "visible":true,
+         "width":3,
+         "x":0,
+         "y":0
+        }],
+ "orientation":"orthogonal",
+ "properties":
+    {
+
+    },
+ "tileheight":32,
+ "tilesets":[
+        {
+         "firstgid":1,
+         "image":"tmw_desert_spacing.png",
+         "imageheight":199,
+         "imagewidth":265,
+         "margin":1,
+         "name":"Desert",
+         "properties":
+            {
+
+            },
+         "spacing":1,
+         "tileheight":32,
+         "tilewidth":32
+        }],
+ "tilewidth":32,
+ "version":1,
+ "width":3
+}

--- a/tmxlib/test/data/equivcheck.tmx
+++ b/tmxlib/test/data/equivcheck.tmx
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map version="1.0" orientation="orthogonal" width="3" height="3" tilewidth="32" tileheight="32">
+ <tileset firstgid="1" name="Desert" tilewidth="32" tileheight="32" spacing="1" margin="1">
+  <image source="tmw_desert_spacing.png" width="265" height="199"/>
+ </tileset>
+ <layer name="Tile layer" width="3" height="3">
+  <data encoding="base64" compression="zlib">
+   eJxjYEAFcgyYAAACfAAf
+  </data>
+ </layer>
+ <objectgroup name="Object Layer" width="3" height="3">
+  <object gid="30" x="32" y="64"/>
+ </objectgroup>
+</map>

--- a/tmxlib/test/data/equivcheck.tmx
+++ b/tmxlib/test/data/equivcheck.tmx
@@ -3,7 +3,7 @@
  <tileset firstgid="1" name="Desert" tilewidth="32" tileheight="32" spacing="1" margin="1">
   <image source="tmw_desert_spacing.png" width="265" height="199"/>
  </tileset>
- <layer name="Tile layer" width="3" height="3">
+ <layer name="Tile Layer" width="3" height="3">
   <data encoding="base64" compression="zlib">
    eJxjYEAFcgyYAAACfAAf
   </data>

--- a/tmxlib/test/test_tmxlib.py
+++ b/tmxlib/test/test_tmxlib.py
@@ -65,6 +65,8 @@ map_filenames = [
             output_filename='sewers.tmx'),
         dict(filename='walls_and_desert.tmx', has_gzip=False,
             output_filename=None),
+        dict(filename='equivcheck.tmx', has_gzip=False,
+            output_filename=None),
     ]
 
 
@@ -327,10 +329,10 @@ def test_tileset_tile():
     map = desert()
     tile = map.tilesets[0][1]
     assert tile.tileset.name == 'Desert'
-    assert tile.size == (32, 32)
+    assert tile.pixel_size == (32, 32)
     assert tile.properties == {}
 
-    assert tile.width == tile.height == 32
+    assert tile.pixel_width == tile.pixel_height == 32
 
     assert map.tilesets[0][0] is not map.tilesets[0][0]  # impl. detail
     assert map.tilesets[0][0] == map.tilesets[0][0]
@@ -346,7 +348,8 @@ def test_map_tile():
     assert tile.map is map
     assert tile.tileset is map.tilesets[0]
     assert tile.tileset_tile == map.tilesets[0][29]
-    assert tile.size == (32, 32)
+    assert tile.size == (1, 1)
+    assert tile.pixel_size == (32, 32)
     assert tile.properties == {}
     tile.value == 1
     map.layers[0].set_value_at((1, 2), 1)
@@ -438,6 +441,7 @@ def test_empty_tile():
     assert tile.value == 0
     assert tile.number == 0
     assert tile.size == (0, 0)
+    assert tile.pixel_size == (0, 0)
     assert tile.properties == {}
 
 
@@ -608,15 +612,25 @@ def test_objects():
     objects = map.layers['Objects']
 
     sign = objects['Sign']
-    assert sign.size == (32, 32)
-    sign.size = 32, 32
-    with pytest.raises(ValueError):
-        sign.size = 1, 1
+
+    assert sign.size == (1, 1)
+    sign.size = 1, 1
+    with pytest.raises(TypeError):
+        sign.size = 10, 10
+
+    assert sign.pixel_size == (32, 32)
+    sign.pixel_size = 32, 32
+    with pytest.raises(TypeError):
+        sign.pixel_size = 3, 3
 
     hole = objects['Hole A']
-    assert hole.size == (53, 85)
-    hole.size = 1, 1
+    assert hole.pixel_size == (53, 85)
+    hole.pixel_size = 32, 10
     assert hole.width == 1
+    assert hole.pixel_width == 32
+    hole.size = 20, 2
+    assert hole.height == 2
+    assert hole.pixel_height == 64
 
     assert hole.pos == (hole.x, hole.y)
     assert hole.pos == (hole.x, hole.y) == (438 / 32, 214 / 32)

--- a/tmxlib/test/test_tmxlib.py
+++ b/tmxlib/test/test_tmxlib.py
@@ -845,3 +845,26 @@ def test_layer_nonzero():
     assert not layer
     layer.append(tmxlib.MapObject(layer, (0, 0), size=(3, 3)))
     assert layer
+
+
+def test_tile_and_object_attr_equivalence():
+    map = tmxlib.Map.open(get_test_filename('equivcheck.tmx'))
+    tile = map.layers['Tile Layer'][1, 1]
+    obj = map.layers['Object Layer'][0]
+
+    def assert_equal_attr(attr_name):
+        assert getattr(tile, attr_name) == getattr(obj, attr_name)
+
+    for attr_name in (
+            'size', 'width', 'height',
+            'pixel_size', 'pixel_width', 'pixel_height',
+            'pos', 'x', 'y',
+            'pixel_pos', 'pixel_x', 'pixel_y',
+            'value', 'gid', 'flipped_horizontally', 'flipped_vertically',
+                'flipped_diagonally',
+            'tileset_tile',
+        ):
+        assert_equal_attr(attr_name)
+
+    with pytest.raises(AssertionError):
+        assert_equal_attr('layer')

--- a/tmxlib/test/test_tmxlib.py
+++ b/tmxlib/test/test_tmxlib.py
@@ -235,7 +235,7 @@ def test_layer_get():
 def test_layer_get_default():
     map = desert()
     assert map.layers.get(50, 3) == 3
-    assert map.layers.get('bad name') == None
+    assert map.layers.get('bad name') is None
     assert map.layers.get(-50, 'default') == 'default'
 
 
@@ -332,7 +332,7 @@ def test_tileset_tile():
 
     assert tile.width == tile.height == 32
 
-    assert map.tilesets[0][0] is not map.tilesets[0][0]  # implementation detail
+    assert map.tilesets[0][0] is not map.tilesets[0][0]  # impl. detail
     assert map.tilesets[0][0] == map.tilesets[0][0]
     assert hash(map.tilesets[0][0]) == hash(map.tilesets[0][0])
 
@@ -358,25 +358,25 @@ def test_map_tile():
 
     tile.gid = 3
     assert tile.value == tile.gid == 3
-    assert tile.flipped_horizontally == False
-    assert tile.flipped_vertically == False
-    assert tile.flipped_diagonally == False
+    assert not tile.flipped_horizontally
+    assert not tile.flipped_vertically
+    assert not tile.flipped_diagonally
 
     tile.flipped_horizontally = True
     assert tile.value == 3 + tmxlib.MapTile.flipped_horizontally.value
     assert tile.value == 0x80000003
-    assert tile.flipped_horizontally == True
-    assert tile.flipped_vertically == False
-    assert tile.flipped_diagonally == False
+    assert tile.flipped_horizontally
+    assert not tile.flipped_vertically
+    assert not tile.flipped_diagonally
     assert tile.gid == 3
 
     tile.flipped_vertically = True
     assert tile.value == (3 + tmxlib.MapTile.flipped_horizontally.value +
         tmxlib.MapTile.flipped_vertically.value)
     assert tile.value == 0xC0000003
-    assert tile.flipped_horizontally == True
-    assert tile.flipped_vertically == True
-    assert tile.flipped_diagonally == False
+    assert tile.flipped_horizontally
+    assert tile.flipped_vertically
+    assert not tile.flipped_diagonally
     assert tile.gid == 3
 
     tile.flipped_diagonally = True
@@ -384,9 +384,9 @@ def test_map_tile():
     assert tile.value == (3 + tmxlib.MapTile.flipped_horizontally.value +
         tmxlib.MapTile.flipped_vertically.value +
         tmxlib.MapTile.flipped_diagonally.value)
-    assert tile.flipped_horizontally == True
-    assert tile.flipped_vertically == True
-    assert tile.flipped_diagonally == True
+    assert tile.flipped_horizontally
+    assert tile.flipped_vertically
+    assert tile.flipped_diagonally
     assert tile.gid == 3
 
     tile.flipped_horizontally = False
@@ -394,9 +394,9 @@ def test_map_tile():
     assert tile.value == (3 +
         tmxlib.MapTile.flipped_vertically.value +
         tmxlib.MapTile.flipped_diagonally.value)
-    assert tile.flipped_horizontally == False
-    assert tile.flipped_vertically == True
-    assert tile.flipped_diagonally == True
+    assert not tile.flipped_horizontally
+    assert tile.flipped_vertically
+    assert tile.flipped_diagonally
     assert tile.gid == 3
 
     assert map.layers[0][1, 2].value == 0x60000003
@@ -720,6 +720,7 @@ def test_autoadd_tileset():
 
     assert tileset in map.tilesets
 
+
 def test_flipping():
     testmap = tmxlib.Map.open(get_test_filename('flip-test.tmx'))
     layer = testmap.layers[0]
@@ -755,6 +756,7 @@ def test_flipping():
     assert_corners(1, 2, 'ylw', 'red', 'blu', 'grn', 1, 0, 0)
     assert_corners(0, 2, 'grn', 'ylw', 'red', 'blu', 1, 1, 1)
     assert_corners(0, 1, 'blu', 'grn', 'ylw', 'red', 0, 1, 0)
+
 
 def test_rotation():
     testmap = tmxlib.Map.open(get_test_filename('flip-test.tmx'))


### PR DESCRIPTION
```
** Pixel measurements have been moved to pixel_size, pixel_width,
    pixel_height (and pixel_pos, ~_x, ~_y) attributes.
    The size, width and height attributes of MapTile and MapObject
    are now in units of map tiles.
```
