### PR TITLE
Vertical position of map object is "artificially" modified

### DIFF
--- a/tmxlib/fileio.py
+++ b/tmxlib/fileio.py
@@ -550,8 +550,9 @@ class TMXSerializer(object):
                 height = int(subelem.attrib.pop('height', 0))
                 if width or height:
                     kwargs['pixel_size'] = int(width), int(height)
-                if not kwargs.get('value'):
-                    y += height
+                # if not kwargs.get('value'):
+                #     y += height
+
                 kwargs['pixel_pos'] = x, y
                 assert not subelem.attrib, (
                     'Unexpected object attributes: %s' % subelem.attrib)

--- a/tmxlib/mapobject.py
+++ b/tmxlib/mapobject.py
@@ -82,11 +82,12 @@ class MapObject(helpers.PixelPosMixin, helpers.LayerElementMixin):
     @property
     def pos(self):
         return (self.pixel_pos[0] / self.layer.map.tile_width,
-                self.pixel_pos[1] / self.layer.map.tile_height - 1)
+                # self.pixel_pos[1] / self.layer.map.tile_height - 1)
+                self.pixel_pos[1] / self.layer.map.tile_height)
     @pos.setter
     def pos(self, value):
         x, y = value
-        y += 1
+        # y += 1
         self.pixel_pos = (x * self.layer.map.tile_width,
                 y * self.layer.map.tile_height)
 


### PR DESCRIPTION
Hey there again!

While working with tmxlib I've noticed my map objects are position incorrectly, especially offseting `y` value by object's height is producing undesired effects. I'm wondering if this is done intentionally or it's a bug?

I've attached a pull request which highlights 2 pieces of code that might affect object positioning, one is the logic that offsets item's `y` value by it's height, second is a piece of code in `mapobject.py` that I can't figure out what is doing.
