### PR TITLE
Add support for the renderorder attribute (new in Tiled 0.10)

### DIFF
--- a/tmxlib/fileio.py
+++ b/tmxlib/fileio.py
@@ -189,6 +189,9 @@ class TMXSerializer(object):
                 base_path=base_path,
                 background_color=background_color,
             )
+        render_order = root.attrib.pop('renderorder', None)
+        if render_order:
+            args['render_order'] = render_order
         assert not root.attrib, 'Unexpected map attributes: %s' % root.attrib
         map = cls(**args)
         for elem in root:
@@ -224,6 +227,8 @@ class TMXSerializer(object):
         if map.background_color:
             elem.attrib['backgroundcolor'] = '#{0}'.format(
                 to_hexcolor(map.background_color))
+        if map.render_order:
+            elem.attrib['renderorder'] = map.render_order
         self.append_properties(elem, map.properties)
         for tileset in map.tilesets:
             elem.append(self.tileset_to_element(tileset,

--- a/tmxlib/map.py
+++ b/tmxlib/map.py
@@ -76,7 +76,8 @@ class Map(fileio.ReadWriteBase, helpers.SizeMixin):
     #   correctly as they can.
     #   And it's not just here...
     def __init__(self, size, tile_size, orientation='orthogonal',
-            background_color=None, base_path=None):
+            background_color=None, base_path=None,
+            render_order=None):
         self.orientation = orientation
         self.size = size
         self.tile_size = tile_size
@@ -85,6 +86,7 @@ class Map(fileio.ReadWriteBase, helpers.SizeMixin):
         self.background_color = background_color
         self.properties = {}
         self.base_path = base_path
+        self.render_order = render_order
 
     @property
     def pixel_size(self):


### PR DESCRIPTION
Fixes https://github.com/encukou/pytmxlib/issues/25
