### PR TITLE
Support object layers from Tiled 0.10+

### DIFF
--- a/tmxlib/fileio.py
+++ b/tmxlib/fileio.py
@@ -273,6 +273,7 @@ class TMXSerializer(object):
                 image=None,
             )
         tileset._read_first_gid = int(elem.attrib.pop('firstgid', 0))
+        tileset.tilecount = int(elem.attrib.pop('tilecount', 0))
         assert not elem.attrib, (
                 'Unexpected tileset attributes: %s' % elem.attrib)
         for subelem in elem:

--- a/tmxlib/fileio.py
+++ b/tmxlib/fileio.py
@@ -535,8 +535,12 @@ class TMXSerializer(object):
                 opacity=float(elem.attrib.pop('opacity', 1)),
                 visible=bool(int(elem.attrib.pop('visible', 1))),
                 color=color)
-        layer_size = (int(elem.attrib.pop('width')),
+        try:
+            layer_size = (int(elem.attrib.pop('width')),
                 int(elem.attrib.pop('height')))
+        except KeyError:
+                layer_size = map.size
+
         assert layer_size == map.size
         assert not elem.attrib, (
             'Unexpected object layer attributes: %s' % elem.attrib)
@@ -549,6 +553,7 @@ class TMXSerializer(object):
                     )
                 x = int(subelem.attrib.pop('x'))
                 y = int(subelem.attrib.pop('y'))
+                subelem_id = int(subelem.attrib.pop('id',0))
 
                 def put(attr_type, attr_name, arg_name):
                     attr = subelem.attrib.pop(attr_name, None)


### PR DESCRIPTION
On Tiled 0.10 and later, object layers have two main differences:
- They may not specify width and height
- Objects have a new "id" attribute

Adding support for both. For now, the object id attribute is not
stored.
