### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://secure.travis-ci.org/encukou/pytmxlib.png?branch=master)](http://travis-ci.org/encukou/pytmxlib)
 [![Coverage Status](https://coveralls.io/repos/encukou/pytmxlib/badge.png?branch=tests)](https://coveralls.io/r/encukou/pytmxlib?branch=tests)
-[![PyPI](https://pypip.in/v/tmxlib/badge.png)](https://crate.io/package/tmxlib)
+[![PyPI](https://img.shields.io/pypi/v/tmxlib.svg)](https://crate.io/package/tmxlib)
 
 tmxlib
 ======


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20tmxlib))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `tmxlib`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.