### PR TITLE
Switch to using collections.abc.MutableSequence

### DIFF
--- a/tmxlib/helpers.py
+++ b/tmxlib/helpers.py
@@ -132,7 +132,7 @@ class TileMixin(SizeMixin, LayerElementMixin):
         self.pixel_size = value[0] * px_parent[0], value[1] * px_parent[1]
 
 
-class NamedElementList(collections.MutableSequence):
+class NamedElementList(collections.abc.MutableSequence):
     """A list that supports indexing by element name, as a convenience, etc
 
     ``lst[some_name]`` means the first `element` where


### PR DESCRIPTION
collections.MutableSequence was removed in favor of collections.abc.MutableSequence. This change fixes the reference and allows the package to install correctly on newer versions of python.